### PR TITLE
Upgrade SvelteKit/Vite to the latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "cookie": "^0.4.1"
       },
       "devDependencies": {
-        "@sveltejs/adapter-node": "^1.0.0-next.78",
-        "@sveltejs/kit": "^1.0.0-next.359",
-        "svelte": "^3.48.0",
-        "vite": "^2.9.13"
+        "@sveltejs/adapter-node": "^1.0.0-next.85",
+        "@sveltejs/kit": "^1.0.0-next.403",
+        "svelte": "^3.49.0",
+        "vite": "^3.0.4"
       },
       "engines": {
         "node": ">=16.7"
@@ -60,21 +60,22 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "1.0.0-next.78",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.78.tgz",
-      "integrity": "sha512-TXB5Ii0z/7o1B05p/YLsS4t+JUHFHWBzFv1U16TKvM3HMbMUJIx+AhpM2WJfDX8HtAyfd1m9OawGoUB+1ed24A==",
+      "version": "1.0.0-next.85",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.85.tgz",
+      "integrity": "sha512-rSiUAbFZbxP0QdcBmtIudR1F1jHUfjUNk7cguUfOnJ9HyuKmXxFctY6lz68pO1bX2kTHf9ixu9DKC7VfDmt2mg==",
       "dev": true,
       "dependencies": {
         "tiny-glob": "^0.2.9"
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.359",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.359.tgz",
-      "integrity": "sha512-3WH198JhOI9rmDlVSPPHlgg+/R/gS4x5cETjYsIw3XckpN2zExDqlYHUBUwk/dEG/12BfPB3rDMNzdZ0QHtubQ==",
+      "version": "1.0.0-next.403",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.403.tgz",
+      "integrity": "sha512-pKlmthl1SZkbx671Jp+LBoRne0vNzsjSgta9iRhqW/bt/0mx/IjlMd/NOeLuJGo30dAJdefrySoSamiaq47M/g==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.48",
+        "@sveltejs/vite-plugin-svelte": "^1.0.1",
         "chokidar": "^3.5.3",
         "sade": "^1.8.1"
       },
@@ -82,33 +83,33 @@
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": ">=16.7"
+        "node": ">=16.9"
       },
       "peerDependencies": {
         "svelte": "^3.44.0",
-        "vite": "^2.9.10"
+        "vite": "^3.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.49",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.49.tgz",
-      "integrity": "sha512-AKh0Ka8EDgidnxWUs8Hh2iZLZovkETkefO99XxZ4sW4WGJ7VFeBx5kH/NIIGlaNHLcrIvK3CK0HkZwC3Cici0A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
+      "integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "debug": "^4.3.4",
         "deepmerge": "^4.2.2",
-        "kleur": "^4.1.4",
+        "kleur": "^4.1.5",
         "magic-string": "^0.26.2",
         "svelte-hmr": "^0.14.12"
       },
       "engines": {
-        "node": "^14.13.1 || >= 16"
+        "node": "^14.18.0 || >= 16"
       },
       "peerDependencies": {
         "diff-match-patch": "^1.0.5",
         "svelte": "^3.44.0",
-        "vite": "^2.9.0"
+        "vite": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "diff-match-patch": {
@@ -883,9 +884,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
-      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
+      "integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -926,21 +927,21 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
-      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
+      "integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.14.27",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "esbuild": "^0.14.47",
+        "postcss": "^8.4.14",
+        "resolve": "^1.22.1",
+        "rollup": "^2.75.6"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": ">=12.2.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -948,7 +949,8 @@
       "peerDependencies": {
         "less": "*",
         "sass": "*",
-        "stylus": "*"
+        "stylus": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "less": {
@@ -958,6 +960,9 @@
           "optional": true
         },
         "stylus": {
+          "optional": true
+        },
+        "terser": {
           "optional": true
         }
       }
@@ -993,35 +998,35 @@
       }
     },
     "@sveltejs/adapter-node": {
-      "version": "1.0.0-next.78",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.78.tgz",
-      "integrity": "sha512-TXB5Ii0z/7o1B05p/YLsS4t+JUHFHWBzFv1U16TKvM3HMbMUJIx+AhpM2WJfDX8HtAyfd1m9OawGoUB+1ed24A==",
+      "version": "1.0.0-next.85",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.85.tgz",
+      "integrity": "sha512-rSiUAbFZbxP0QdcBmtIudR1F1jHUfjUNk7cguUfOnJ9HyuKmXxFctY6lz68pO1bX2kTHf9ixu9DKC7VfDmt2mg==",
       "dev": true,
       "requires": {
         "tiny-glob": "^0.2.9"
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.359",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.359.tgz",
-      "integrity": "sha512-3WH198JhOI9rmDlVSPPHlgg+/R/gS4x5cETjYsIw3XckpN2zExDqlYHUBUwk/dEG/12BfPB3rDMNzdZ0QHtubQ==",
+      "version": "1.0.0-next.403",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.403.tgz",
+      "integrity": "sha512-pKlmthl1SZkbx671Jp+LBoRne0vNzsjSgta9iRhqW/bt/0mx/IjlMd/NOeLuJGo30dAJdefrySoSamiaq47M/g==",
       "dev": true,
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.48",
+        "@sveltejs/vite-plugin-svelte": "^1.0.1",
         "chokidar": "^3.5.3",
         "sade": "^1.8.1"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.49",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.49.tgz",
-      "integrity": "sha512-AKh0Ka8EDgidnxWUs8Hh2iZLZovkETkefO99XxZ4sW4WGJ7VFeBx5kH/NIIGlaNHLcrIvK3CK0HkZwC3Cici0A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
+      "integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1",
         "debug": "^4.3.4",
         "deepmerge": "^4.2.2",
-        "kleur": "^4.1.4",
+        "kleur": "^4.1.5",
         "magic-string": "^0.26.2",
         "svelte-hmr": "^0.14.12"
       }
@@ -1477,9 +1482,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
-      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
+      "integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
       "dev": true
     },
     "svelte-hmr": {
@@ -1509,16 +1514,16 @@
       }
     },
     "vite": {
-      "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
-      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
+      "integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.14.27",
+        "esbuild": "^0.14.47",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "postcss": "^8.4.14",
+        "resolve": "^1.22.1",
+        "rollup": "^2.75.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "cookie": "^0.4.1"
   },
   "devDependencies": {
-    "@sveltejs/adapter-node": "^1.0.0-next.78",
-    "@sveltejs/kit": "^1.0.0-next.359",
-    "svelte": "^3.48.0",
-    "vite": "^2.9.13"
+    "@sveltejs/adapter-node": "^1.0.0-next.85",
+    "@sveltejs/kit": "^1.0.0-next.403",
+    "svelte": "^3.49.0",
+    "vite": "^3.0.4"
   },
   "type": "module",
   "engines": {

--- a/src/routes/todos/[uid].json.js
+++ b/src/routes/todos/[uid].json.js
@@ -1,7 +1,7 @@
 import { api } from './_api';
 
 // PATCH /todos/:uid.json
-export const patch = async (event) => {
+export const PATCH = async (event) => {
 	const data = await event.request.formData();
 
 	return api(event, `todos/${event.locals.userid}/${event.params.uid}`, {
@@ -11,6 +11,6 @@ export const patch = async (event) => {
 };
 
 // DELETE /todos/:uid.json
-export const del = async (event) => {
+export const DELETE = async (event) => {
 	return api(event, `todos/${event.locals.userid}/${event.params.uid}`);
 };

--- a/src/routes/todos/index.json.js
+++ b/src/routes/todos/index.json.js
@@ -1,7 +1,7 @@
 import { api } from './_api';
 
 // GET /todos.json
-export const get = async (event) => {
+export const GET = async (event) => {
 	// event.locals.userid comes from src/hooks.js
 	const response = await api(event, `todos/${event.locals.userid}`);
 
@@ -15,7 +15,7 @@ export const get = async (event) => {
 };
 
 // POST /todos.json
-export const post = async (event) => {
+export const POST = async (event) => {
 	const data = await event.request.formData();
 
 	const response = await api(event, `todos/${event.locals.userid}`, {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,7 +1,6 @@
-/** @type {import('@sveltejs/kit').Config} */
-
 import node from '@sveltejs/adapter-node';
 
+/** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
 		adapter: node(),


### PR DESCRIPTION
This upgrades SvelteKit and Vite to the latest versions and updates this example to address [breaking changes](https://github.com/sveltejs/kit/discussions/5359) (https://github.com/render-examples/sveltekit/commit/7b0ec71bf83bb4b86baa86c5991930412d395d16).

Best reviewed by commit.