### PR TITLE
Fix render.yaml: "env" --> "runtime"

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - type: web
     name: sveltekit
-    env: node
+    runtime: node
     buildCommand: npm install && npm run build
     startCommand: node build/index.js
     autoDeploy: false


### PR DESCRIPTION
Per the [render.yaml schema](https://docs.render.com/blueprint-spec#runtime), `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.